### PR TITLE
Update dependency webpack-dev-server to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "react-dom": "^16.3.1"
   },
   "devDependencies": {
-    "webpack-dev-server": "2.11.2",
+    "webpack-dev-server": "3.1.1",
     "yarn": "^1.5.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1214,7 +1214,7 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.1, chalk@^2.3.2:
+chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
   dependencies:
@@ -3357,9 +3357,19 @@ lodash.uniq@^4.5.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
+log-symbols@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  dependencies:
+    chalk "^2.0.1"
+
 loglevel@^1.4.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
+
+loglevelnext@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/loglevelnext/-/loglevelnext-1.0.3.tgz#0f69277e73bbbf2cd61b94d82313216bf87ac66e"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -3371,7 +3381,7 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   dependencies:
     js-tokens "^3.0.0"
 
-loud-rejection@^1.0.0:
+loud-rejection@^1.0.0, loud-rejection@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
   dependencies:
@@ -3517,9 +3527,9 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
-mime@^1.5.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+mime@^2.1.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.2.2.tgz#6b4c109d88031d7b5c23635f5b923da336d79121"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -5672,10 +5682,6 @@ thunky@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.0.2.tgz#a862e018e3fb1ea2ec3fce5d55605cf57f247371"
 
-time-stamp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-2.0.0.tgz#95c6a44530e15ba8d6f4a3ecb8c3a3fac46da357"
-
 timers-browserify@^2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.6.tgz#241e76927d9ca05f4d959819022f5b3664b64bae"
@@ -5877,6 +5883,10 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
 
+url-join@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.0.tgz#4d3340e807d3773bda9991f8305acdcc2a665d2a"
+
 url-parse@1.0.x:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.0.5.tgz#0854860422afdcfefeb6c965c662d4800169927b"
@@ -5969,19 +5979,21 @@ wbuf@^1.1.0, wbuf@^1.7.2:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-webpack-dev-middleware@1.12.2:
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz#f8fc1120ce3b4fc5680ceecb43d777966b21105e"
+webpack-dev-middleware@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.0.1.tgz#7ffd6d0192883c83d3f262e8d7dec822493c6166"
   dependencies:
+    loud-rejection "^1.6.0"
     memory-fs "~0.4.1"
-    mime "^1.5.0"
+    mime "^2.1.0"
     path-is-absolute "^1.0.0"
     range-parser "^1.0.3"
-    time-stamp "^2.0.0"
+    url-join "^4.0.0"
+    webpack-log "^1.0.1"
 
-webpack-dev-server@2.11.2:
-  version "2.11.2"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz#1f4f4c78bf1895378f376815910812daf79a216f"
+webpack-dev-server@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.1.1.tgz#3c0fdd1ba3b50ebc79858a0e6b9ccdd1565b0c24"
   dependencies:
     ansi-html "0.0.7"
     array-includes "^3.0.3"
@@ -6008,8 +6020,18 @@ webpack-dev-server@2.11.2:
     spdy "^3.4.1"
     strip-ansi "^3.0.0"
     supports-color "^5.1.0"
-    webpack-dev-middleware "1.12.2"
-    yargs "6.6.0"
+    webpack-dev-middleware "3.0.1"
+    webpack-log "^1.1.2"
+    yargs "9.0.1"
+
+webpack-log@^1.0.1, webpack-log@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-1.2.0.tgz#a4b34cda6b22b518dbb0ab32e567962d5c72a43d"
+  dependencies:
+    chalk "^2.1.0"
+    log-symbols "^2.1.0"
+    loglevelnext "^1.0.1"
+    uuid "^3.1.0"
 
 webpack-manifest-plugin@^1.3.2:
   version "1.3.2"
@@ -6132,12 +6154,6 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yargs-parser@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
-  dependencies:
-    camelcase "^3.0.0"
-
 yargs-parser@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
@@ -6150,23 +6166,23 @@ yargs-parser@^7.0.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
+yargs@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-9.0.1.tgz#52acc23feecac34042078ee78c0c007f5085db4c"
   dependencies:
-    camelcase "^3.0.0"
+    camelcase "^4.1.0"
     cliui "^3.2.0"
     decamelize "^1.1.1"
     get-caller-file "^1.0.1"
-    os-locale "^1.4.0"
-    read-pkg-up "^1.0.1"
+    os-locale "^2.0.0"
+    read-pkg-up "^2.0.0"
     require-directory "^2.1.1"
     require-main-filename "^1.0.1"
     set-blocking "^2.0.0"
-    string-width "^1.0.2"
-    which-module "^1.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
     y18n "^3.2.1"
-    yargs-parser "^4.2.0"
+    yargs-parser "^7.0.0"
 
 yargs@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
This Pull Request updates dependency [webpack-dev-server](https://github.com/webpack/webpack-dev-server) from `v2.11.2` to `v3.1.1`



<details>
<summary>Release Notes</summary>

### [`v3.0.0`](https://github.com/webpack/webpack-dev-server/releases/v3.0.0)

#### Updates

- **Breaking change:** webpack v4 is now supported. Older versions of webpack are **not** supported.
- **Breaking change:** drops support for Node.js v4, going forward we only support v6+ (same as webpack).
- webpack-dev-middleware updated to v2 ([see changes](https://github.com/webpack/webpack-dev-middleware/releases)).
#### Bugfixes

- After starting webpack-dev-server with an error in your code, it would not reload the page after fixing that error (#&#8203;1317).
- DynamicEntryPlugin is now supported correctly (#&#8203;1319).

Huge thanks to all the contributors!

Please note that [webpack-serve](https://github.com/webpack-contrib/webpack-serve) will eventually be the successor of webpack-dev-server. The core features already work so if you're brave enough give it a try!

---

### [`v3.1.0`](https://github.com/webpack/webpack-dev-server/releases/v3.1.0)

#### Updates

- Fancy logging; `webpack-log` is now used for logging to the terminal (webpack-dev-middleware was already using this).
- The `logLevel` option is added for more fine-grained control over the logging.
#### Bugfixes

- MultiCompiler was broken with webpack 4.
- Fix deprecation warnings caused by webpack 4. Note that you will still see some deprecation warnings because webpack-dev-middleware has not been updated yet.

---

### [`v3.1.1`](https://github.com/webpack/webpack-dev-server/releases/v3.1.1)

- Update to [webpack-dev-middleware v3](https://github.com/webpack/webpack-dev-middleware/releases/tag/v3.0.0), which removes the deprecation warnings from webpack.

---

</details>


<details>
<summary>Commits</summary>

#### v3.0.0
-   [`f4f14ce`](https://github.com/webpack/webpack-dev-server/commit/f4f14cec31f25ffb46898d1e281fe9569a8569ae) Fix support for DynamicEntryPlugin (#&#8203;1319)
-   [`dbea323`](https://github.com/webpack/webpack-dev-server/commit/dbea323cf2015ad09063e437ff1dfb5b4918befe) Update deps
-   [`ab4eeb0`](https://github.com/webpack/webpack-dev-server/commit/ab4eeb007283fdf3e8950ff1f3ff8150a4812061) Fix page not reloading after fixing first error on page (#&#8203;1317)
-   [`7378e3e`](https://github.com/webpack/webpack-dev-server/commit/7378e3e33f512922da0a8b9c41304387f4d47917) Merge branch &#x27;webpack-4&#x27;
-   [`cdd10fa`](https://github.com/webpack/webpack-dev-server/commit/cdd10fa4f757f3202e4948421a6428c55042020d) Stop testing node v4 on travis ci
-   [`1e7acca`](https://github.com/webpack/webpack-dev-server/commit/1e7acca5baf9124f2155c8accb35f300e06ad579) Actually make the yargs version test do something
-   [`dfe137c`](https://github.com/webpack/webpack-dev-server/commit/dfe137cc86c316d7dad4e3cc7dae05596952764c) Hopefully fix failing CI tests (the hacky way)
-   [`eedf10f`](https://github.com/webpack/webpack-dev-server/commit/eedf10f5eb31be46aec3f286ade4bf6572965c82) Try again at fixing CI by upping timeout (necessary for node v6)
-   [`6e1d886`](https://github.com/webpack/webpack-dev-server/commit/6e1d886d30bc8067067d33ba85c2ed810a4d1e2c) 3.0.0
#### v3.1.0
-   [`f0534fc`](https://github.com/webpack/webpack-dev-server/commit/f0534fc3b900735a6474207365209406cda574ad) Use webpack-log for logging
-   [`d20757b`](https://github.com/webpack/webpack-dev-server/commit/d20757b6598dacc555d47c4bf9a6695ba8e9e05d) Upgrade another timeout for slow CI
-   [`94398c4`](https://github.com/webpack/webpack-dev-server/commit/94398c40a27ee37c64f22c41777c74cc5f0dee17) 3.1.0
#### v3.1.1
-   [`f2db057`](https://github.com/webpack/webpack-dev-server/commit/f2db057ac105ec945f0e62dba64441c4ccfde59c) Don&#x27;t invoke function on static html string (#&#8203;1329)
-   [`ef55984`](https://github.com/webpack/webpack-dev-server/commit/ef5598440ebf6847ac02a2d44d7fec70efee0aa1) Remove Tapable#apply calls (#&#8203;1331)
-   [`2b40391`](https://github.com/webpack/webpack-dev-server/commit/2b40391bcfa848d5d8e61f5cbeaf350e01198c39) Upgrade webpack-dev-middleware dependency
-   [`3c9592e`](https://github.com/webpack/webpack-dev-server/commit/3c9592e1c46f5a377058b2d3db4887f44a890345) Actually upgrade package-lock.json...
-   [`7b9269e`](https://github.com/webpack/webpack-dev-server/commit/7b9269e3d2c628869602419396db8990351eec73) Update deps
-   [`34a6cc3`](https://github.com/webpack/webpack-dev-server/commit/34a6cc3085fe221cc89974ed12e80d3031a12baa) And update pinned webpack-dev-middleware
-   [`3a7f7d5`](https://github.com/webpack/webpack-dev-server/commit/3a7f7d543889707725e5d60fc21fe2de975d627d) 3.1.1

</details>